### PR TITLE
No sep ending

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,49 @@
+name: CMake
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: Debug (Linux)
+            os: ubuntu-latest
+            build_type: Release
+            
+          - name: Debug (MacOS)
+            os: macos-latest
+            build_type: Release
+            
+          - name: Release (Linux)
+            os: ubuntu-latest
+            build_type: Release
+            
+          - name: Release (MacOS)
+            os: macos-latest
+            build_type: Release
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build
+      run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: ${{ github.workspace }}/build
+      run: ctest -C ${{ matrix.build_type }}
+      

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # cleanpath
 
+[![CMake](https://github.com/jhunkeler/cleanpath/actions/workflows/cmake.yml/badge.svg)](https://github.com/jhunkeler/cleanpath/actions/workflows/cmake.yml)
+
 `cleanpath` is a utility that filters unwanted elements from an environment variable.
+
 
 # Installation
 

--- a/lib/cleanpath.c
+++ b/lib/cleanpath.c
@@ -1,19 +1,20 @@
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 #include <regex.h>
-#include "cleanpath.h"
 #include "config.h"
+#include "cleanpath.h"
 
 #if OS_LINUX
-#ifdef HAVE_SYS_LIMIT_H
+#if HAVE_SYS_LIMIT_H
 #include <sys/limits.h>
 #endif  // HAVE_SYS_LIMIT_H
 
-#ifdef HAVE_LINUX_LIMIT_H
+#if HAVE_LINUX_LIMIT_H
 #include <linux/limits.h>
 #endif  // HAVE_LINUX_LIMIT_H
-#endif  // OS_LINUX
+#else
+#include <limits.h>
+#endif
 
 /**
  * Split path into parts by sep

--- a/lib/cleanpath.c
+++ b/lib/cleanpath.c
@@ -102,7 +102,7 @@ char *cleanpath_read(struct CleanPath *path) {
         strcat(result, path->part[i]);
 
         // Do not append path separator on final element
-        if (path->part[i + 1] != NULL) {
+        if (path->part[i + 1] != NULL && *path->part[i + 1] != '\0') {
             strcat(result, path->sep);
         }
     }

--- a/tests/test_no_sep_ending.c
+++ b/tests/test_no_sep_ending.c
@@ -1,0 +1,19 @@
+#include "cleanpath.h"
+#include "framework.h"
+
+int main() {
+    const char *input = "/usr/bin:/usr/sbin:/sbin:/bin:";
+    struct CleanPath *path;
+    char *result;
+    size_t len;
+
+    result = NULL;
+    path = cleanpath_init(input, TEST_SEP);
+    cleanpath_filter(path, CLEANPATH_FILTER_REGEX, "/bin");
+    result = cleanpath_read(path);
+    cleanpath_free(path);
+
+    len = strlen(result);
+    puts(result);
+    myassert(len && *(result + (len - 1)) != TEST_SEP[0], "Result ends with a separator:\n'%s'", result);
+}


### PR DESCRIPTION
I noticed if only the last element in a string was filtered the separator would be injected into the output string. This fixes that.